### PR TITLE
Fix: Adjust text color

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,13 +21,13 @@ const App = () => {
             </div>
             <ul tabIndex={0}
               className="menu dropdown-content mt-2 z-[1] border border-indigo-600 bg-base-100 rounded-2xl w-42">
-              <li><Link to="/">메인</Link></li>
-              <li><Link to="/about">소개</Link></li>
-              <li><Link to="/contribute">기여</Link></li>
+              <li><Link to="/"><span className="text-neutral-content">메인</span></Link></li>
+              <li><Link to="/about"><span className="text-neutral-content">소개</span></Link></li>
+              <li><Link to="/contribute"><span className="text-neutral-content">기여</span></Link></li>
               {/* Social (Mobile) */}
               <div className="block md:hidden">
-                <li><a href="https://github.com/currenjin/site-for-developers" rel="noreferrer" target="_blank">GitHub</a></li>
-                <li><a href="https://stats.uptimerobot.com/Klr3b7eDKs" rel="noreferrer" target="_blank">웹사이트 상태</a></li>
+                <li><a href="https://github.com/currenjin/site-for-developers" rel="noreferrer" target="_blank"><span className="text-neutral-content">GitHub</span></a></li>
+                <li><a href="https://stats.uptimerobot.com/Klr3b7eDKs" rel="noreferrer" target="_blank"><span className="text-neutral-content">웹사이트 상태</span></a></li>
               </div>
             </ul>
           </div>
@@ -45,12 +45,12 @@ const App = () => {
           <div className="hidden md:flex">
           <button className="btn btn-ghost btn-circle">
             <a href="https://github.com/currenjin/site-for-developers" rel="noreferrer" target="_blank">
-              <FaGithub size={26} />
+              <FaGithub size={26} className="text-neutral-content" />
             </a>
           </button>
           <button className="btn btn-ghost btn-circle">
             <a href="https://stats.uptimerobot.com/Klr3b7eDKs" rel="noreferrer" target="_blank">
-              <FaCheckCircle size={26} />
+              <FaCheckCircle size={26} className="text-neutral-content" />
             </a>
           </button>
           </div>


### PR DESCRIPTION
@currenjin 
Navbar의 일부 내용이 잘 안보이는 이슈가 있는 거 같아서 text color를 `text-neutral-content`로 적용했습니다.
수정한 부분은 다음과 같습니다.
- Navbar -> 검색어 입력 Input의 우측에 있는 `링크 아이콘`
- Navbar -> 로고 좌측의 메뉴에 들어있는 `메뉴 링크 텍스트`

PR 검토 해보시고 의견 부탁드립니다!

- AS IS
![image](https://github.com/user-attachments/assets/20c0fe26-0585-43bb-8503-39a7b01ef608)
![image](https://github.com/user-attachments/assets/1a98413f-af1a-489e-8509-f8364245f7df)

- TO BE
![image](https://github.com/user-attachments/assets/2f67d7c5-6abc-4f8c-ad8f-5df28973c2d7)
![image](https://github.com/user-attachments/assets/2a5aedaa-fc29-4fa0-992b-d046d1a3f232)

- 물론 Mobile도 잘 보입니다!
![image](https://github.com/user-attachments/assets/79fe93bd-679c-402b-8fae-d504d432975f)
