### PR TITLE
Fix link formatting for Google Labs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@
 
   - [팔만코딩경 <sub>KR</sub>](https://80000coding.oopy.io/) - 개발 관련 자료모음
   - [토리맘의 한글라이즈 프로젝트 <sub>KR</sub>](https://godekdls.github.io/) - Spring Boot 한글 번역 문서
-  - [Google Labs <sub>EN</sub>](https://haebom.dev/51q3vdn2p96kmxy49prk) - Google 실험실
+  - [Google Labs <sub>EN</sub>]((https://labs.google/)) - Google 실험실
 
   - <span id="awesome">Awesome</span>
     - [Awesome <sub>EN, O</sub>](https://github.com/sindresorhus/awesome) - 프로그래밍 관련 자료모음

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@
 
   - [팔만코딩경 <sub>KR</sub>](https://80000coding.oopy.io/) - 개발 관련 자료모음
   - [토리맘의 한글라이즈 프로젝트 <sub>KR</sub>](https://godekdls.github.io/) - Spring Boot 한글 번역 문서
-  - [Google Labs <sub>EN</sub>]((https://labs.google/)) - Google 실험실
+  - [Google Labs <sub>EN</sub>](https://labs.google/) - Google 실험실
 
   - <span id="awesome">Awesome</span>
     - [Awesome <sub>EN, O</sub>](https://github.com/sindresorhus/awesome) - 프로그래밍 관련 자료모음


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 변경 사항

google labs 사이트가 '해봄'이라는 블로그로 연결되어있어 수정했습니다.


## 📝 변경 타입

- [ ] 🌟 새 사이트 추가
- [✔️] 📝 기존 사이트 정보 수정
- [ ] 🗑️ 기존 사이트 삭제
- [ ] 🐛 오타/죽은 링크 수정
- [ ] 📚 문서 개선
- [ ] 🔧 기타 개선사항

## ✅ 체크리스트

- [✔️] 추가/수정한 사이트가 정상적으로 접속되는지 확인했습니다
- [✔️] 기존 사이트와 중복되지 않는지 확인했습니다
- [✔️] 적절한 카테고리에 반영했습니다
- [✔️] 라벨(한국어/영어, 무료/유료, 오픈소스)을 올바르게 표시했습니다
- [✔️] README.md만 업데이트했습니다 (이 저장소는 README 단일 소스 정책)

## 📎 추가 정보

**관련 이슈**: (해당하는 경우 #이슈번호)

**테스트 완료**:
- [✔️] 링크 접속 테스트

**추가 의견**:
